### PR TITLE
ECC-981 refactor access logic to check enrolment at a later stage

### DIFF
--- a/app/uk/gov/hmrc/customs/rosmfrontend/controllers/CdsController.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/controllers/CdsController.scala
@@ -24,16 +24,13 @@ import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, allEnrolments, internalId, email => ggEmail, _}
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.customs.rosmfrontend.controllers.auth.{AccessController, AuthRedirectSupport, EnrolmentExtractor}
-import uk.gov.hmrc.customs.rosmfrontend.controllers.routes.EnrolmentAlreadyExistsController.enrolmentAlreadyExists
 import uk.gov.hmrc.customs.rosmfrontend.domain._
-import uk.gov.hmrc.customs.rosmfrontend.models.Journey
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.{ExecutionContext, Future}
 
-abstract class CdsController(mcc: MessagesControllerComponents)(implicit ec: ExecutionContext)
-    extends FrontendController(mcc) with I18nSupport with AuthorisedFunctions with AuthRedirectSupport
-    with EnrolmentExtractor with AccessController {
+abstract class CdsController(mcc: MessagesControllerComponents)(implicit ec: ExecutionContext) extends FrontendController(mcc) with I18nSupport with AuthorisedFunctions with AuthRedirectSupport
+  with EnrolmentExtractor with AccessController {
 
   def authConnector: AuthConnector
 
@@ -76,15 +73,8 @@ abstract class CdsController(mcc: MessagesControllerComponents)(implicit ec: Exe
     userCredentialRole: Option[CredentialRole],
     groupId: Option[String]
   )(implicit request: Request[AnyContent]) = {
-    val cdsLoggedInUser =
-      LoggedInUserWithEnrolments(userAffinityGroup, userInternalId, userAllEnrolments, currentUserEmail, groupId)
-    val journey = if (request.path.contains("register-for-cds")) Journey.GetYourEORI else Journey.Migrate
-    permitUserOrRedirect(userAffinityGroup, userCredentialRole, currentUserEmail) {
-      enrolledEori(cdsLoggedInUser) match {
-        case Some(_) => Future.successful(Redirect(enrolmentAlreadyExists(journey)))
-        case None =>
-          requestProcessor fold (_(request)(userInternalId)(cdsLoggedInUser), _(request)(cdsLoggedInUser))
-      }
-    }
+    val cdsLoggedInUser = LoggedInUserWithEnrolments(userAffinityGroup, userInternalId, userAllEnrolments, currentUserEmail, groupId)
+    permitUserOrRedirect(cdsLoggedInUser, userAffinityGroup, userCredentialRole, currentUserEmail)(requestProcessor fold(_ (request)(userInternalId)(cdsLoggedInUser), _ (request)(cdsLoggedInUser)))
   }
+
 }

--- a/app/uk/gov/hmrc/customs/rosmfrontend/controllers/CdsController.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/controllers/CdsController.scala
@@ -74,7 +74,9 @@ abstract class CdsController(mcc: MessagesControllerComponents)(implicit ec: Exe
     groupId: Option[String]
   )(implicit request: Request[AnyContent]) = {
     val cdsLoggedInUser = LoggedInUserWithEnrolments(userAffinityGroup, userInternalId, userAllEnrolments, currentUserEmail, groupId)
-    permitUserOrRedirect(cdsLoggedInUser, userAffinityGroup, userCredentialRole, currentUserEmail)(requestProcessor fold(_ (request)(userInternalId)(cdsLoggedInUser), _ (request)(cdsLoggedInUser)))
+    permitUserOrRedirect(cdsLoggedInUser, userAffinityGroup, userCredentialRole, currentUserEmail)(
+      requestProcessor.fold(req => req.apply(request)(userInternalId)(cdsLoggedInUser), req => req.apply(request)(cdsLoggedInUser)) //permitted 'Action' which is executed if all checks pass
+    )
   }
 
 }

--- a/app/uk/gov/hmrc/customs/rosmfrontend/controllers/EmailController.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/controllers/EmailController.scala
@@ -100,6 +100,7 @@ class EmailController @Inject()(
           }
         }
       } else {
+        //subscription journey
         userGroupIdSubscriptionStatusCheckService.checksToProceed(GroupId(user.groupId), InternalId(user.internalId)) {
           continue(journey)
         } { groupIsEnrolled(journey) } {

--- a/app/uk/gov/hmrc/customs/rosmfrontend/controllers/auth/AccessController.scala
+++ b/app/uk/gov/hmrc/customs/rosmfrontend/controllers/auth/AccessController.scala
@@ -19,33 +19,64 @@ package uk.gov.hmrc.customs.rosmfrontend.controllers.auth
 import play.api.i18n.I18nSupport
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{AnyContent, Request, Result}
-import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Organisation}
+import uk.gov.hmrc.auth.core.AffinityGroup.Agent
 import uk.gov.hmrc.auth.core.{AffinityGroup, CredentialRole, User}
-import uk.gov.hmrc.customs.rosmfrontend.controllers.{routes, JourneyTypeFromUrl}
+import uk.gov.hmrc.customs.rosmfrontend.controllers.{JourneyTypeFromUrl, routes}
+import uk.gov.hmrc.customs.rosmfrontend.domain.LoggedInUserWithEnrolments
 import uk.gov.hmrc.customs.rosmfrontend.models.Journey
 
 import scala.concurrent.Future
 
-trait AccessController extends JourneyTypeFromUrl with AllowlistVerification with I18nSupport {
+trait AccessController extends JourneyTypeFromUrl with AllowlistVerification with EnrolmentExtractor with I18nSupport {
 
+  /*
+  * Current check order based on https://jira.tools.tax.service.gov.uk/browse/ECC-981:
+  * 1. Check User type (Agent check) & email check
+  * 2. Check enrolment
+  * 3. Organisation Cred Role Assistant check
+  * */
   def permitUserOrRedirect(
+    loggedInUser: LoggedInUserWithEnrolments,
     affinityGroup: Option[AffinityGroup],
     credentialRole: Option[CredentialRole],
     email: Option[String]
-  )(action: Future[Result])(implicit request: Request[AnyContent]): Future[Result] =
-    (isPermittedUserType(affinityGroup, credentialRole), isPermitted(email)) match {
-      case (true, true)  => action
-      case (true, false) => Future.successful(Redirect(routes.YouCannotUseServiceController.unauthorisedPage()))
-      case (false, _)    => Future.successful(Redirect(routes.YouCannotUseServiceController.page(journeyFromUrl)))
-    }
+  )(action: => Future[Result])(implicit request: Request[AnyContent]): Future[Result] = {
+    val journey = if (request.path.contains("register-for-cds")) Journey.GetYourEORI else Journey.Migrate
 
-  def isPermitted(email: Option[String])(implicit request: Request[AnyContent]): Boolean =
+    (isPermittedUserType(affinityGroup), isPermitted(email)) match {
+      case (true, true) =>
+        if (isEnrolled(loggedInUser)) {
+          Future.successful(Redirect(routes.EnrolmentAlreadyExistsController.enrolmentAlreadyExists(journey)))
+        } else {
+          if (isPermittedCredentialRole(credentialRole))
+            action
+          else
+            Future.successful(Redirect(routes.YouCannotUseServiceController.page(journeyFromUrl)))
+        }
+      case (true, false) => Future.successful(Redirect(routes.YouCannotUseServiceController.unauthorisedPage()))
+      case (false, _) => Future.successful(Redirect(routes.YouCannotUseServiceController.page(journeyFromUrl)))
+    }
+  }
+
+  private def isEnrolled(loggedInUser: LoggedInUserWithEnrolments) = {
+    enrolledEori(loggedInUser) match {
+      case Some(_) => true
+      case None => false
+    }
+  }
+
+  private def isPermitted(email: Option[String])(implicit request: Request[AnyContent]): Boolean =
     journeyFromUrl == Journey.GetYourEORI || isAllowlisted(email)
 
-  def isPermittedUserType(affinityGroup: Option[AffinityGroup], credentialRole: Option[CredentialRole]): Boolean =
+  private def isPermittedUserType(affinityGroup: Option[AffinityGroup]): Boolean =
     affinityGroup match {
-      case Some(Agent)        => false
-      case Some(Organisation) => credentialRole.fold(false)(cr => cr == User)
-      case _                  => true
+      case Some(Agent) => false
+      case _ => true
+    }
+
+  private def isPermittedCredentialRole(credentialRole: Option[CredentialRole]): Boolean =
+    credentialRole match {
+      case Some(User) => true
+      case _ => false
     }
 }

--- a/test/util/ControllerSpec.scala
+++ b/test/util/ControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.i18n.{I18nSupport, Messages, MessagesApi, MessagesImpl}
 import play.api.mvc._
 import play.api.test.Helpers._
 import play.api.{Configuration, Environment, Play}
-import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.{Assistant, AuthConnector, CredentialRole}
 import uk.gov.hmrc.customs.rosmfrontend.config.AppConfig
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -95,6 +95,26 @@ trait ControllerSpec extends UnitSpec with GuiceOneAppPerSuite with MockitoSugar
       )
     }
 
+    s"redirect to enrolment-already-exists page when a user already has an EORI enrolment on GG and is Assistant for a Get An EORI Journey $additionalLabel" in {
+      withAuthorisedUser(defaultUserId, mockAuthConnector, cdsEnrolmentId = cdsEnrolmentId, userCredentialRole = Some(Assistant))
+
+      val result = action.apply(SessionBuilder.buildRequestWithSession(defaultUserId))
+      status(result) shouldBe SEE_OTHER
+      header(LOCATION, result) shouldBe Some(
+        "/customs/subscribe-for-cds/enrolment-already-exists"
+      )
+    }
+
+    s"redirect to you-cannot-use-service page when a user doesn't have an EORI enrolment on GG and is Assistant for a Get An EORI Journey $additionalLabel" in {
+      withAuthorisedUser(defaultUserId, mockAuthConnector, cdsEnrolmentId = None, userCredentialRole = Some(Assistant))
+
+      val result = action.apply(SessionBuilder.buildRequestWithSession(defaultUserId))
+      status(result) shouldBe SEE_OTHER
+      header(LOCATION, result) shouldBe Some(
+        "/customs/subscribe-for-cds/you-cannot-use-service"
+      )
+    }
+
     s"redirect to Complete page when a user already has an EORI enrolment on GG for a Get An EORI Journey $additionalLabel" in {
       withAuthorisedUser(defaultUserId, mockAuthConnector, cdsEnrolmentId = cdsEnrolmentId)
 
@@ -116,6 +136,26 @@ trait ControllerSpec extends UnitSpec with GuiceOneAppPerSuite with MockitoSugar
       status(result) shouldBe SEE_OTHER
       header(LOCATION, result) shouldBe Some(
         s"/bas-gateway/sign-in?continue_url=http%3A%2F%2Flocalhost%3A9830%2Fcustoms%2Fsubscribe-for-cds%2Fsubscribe&origin=customs-rosm-frontend"
+      )
+    }
+
+    "redirect to enrolment-already-exists page when a user already has an EORI enrolment on GG and is Assistant for a Subscription Journey" in {
+      withAuthorisedUser(defaultUserId, mockAuthConnector, cdsEnrolmentId = cdsEnrolmentId, userCredentialRole = Some(Assistant))
+
+      val result = action.apply(SessionBuilder.buildRequestWithSession(defaultUserId))
+      status(result) shouldBe SEE_OTHER
+      header(LOCATION, result) shouldBe Some(
+        "/customs/subscribe-for-cds/enrolment-already-exists"
+      )
+    }
+
+    "redirect to you-cannot-use-service page when a user doesn't have an EORI enrolment on GG and is Assistant for a Subscription Journey" in {
+      withAuthorisedUser(defaultUserId, mockAuthConnector, cdsEnrolmentId = None, userCredentialRole = Some(Assistant))
+
+      val result = action.apply(SessionBuilder.buildRequestWithSession(defaultUserId))
+      status(result) shouldBe SEE_OTHER
+      header(LOCATION, result) shouldBe Some(
+        "/customs/subscribe-for-cds/you-cannot-use-service"
       )
     }
 


### PR DESCRIPTION
Changing the order of the checks during authorisation call - https://jira.tools.tax.service.gov.uk/browse/ECC-981.

Previous order:
  1. Check User type (Agent check) & email check (checking Cred Role was included in User Type check)
  3. Check enrolment 

New order:
  1. Check User type (Agent check) & email check
  2. Check enrolment
  3. Organisation Cred Role Assistant check